### PR TITLE
Fix assetName for textures when the parent ldtk is in a nested folder

### DIFF
--- a/LDtk/Renderer/LDtkRenderer.cs
+++ b/LDtk/Renderer/LDtkRenderer.cs
@@ -170,7 +170,9 @@ public class LDtkRenderer
         else
         {
             string file = Path.ChangeExtension(path, null);
-            return content.Load<Texture2D>(file);
+            string directory = Path.GetDirectoryName(level.WorldFilePath);
+            string assetName = string.IsNullOrEmpty(directory) ? file : $"{directory}/{file}";
+            return content.Load<Texture2D>(assetName);
         }
     }
 


### PR DESCRIPTION
The path in the ldtk file is relative to itself, but the asset name is a path relative to the content folder. Since larger projects will have a folder structure under the content folder. The `content.Load<T>` needs to respect that structure. This gets the folder(s) in between content and the ldtk file and prepends it to the filename. It just passes the file through if in the root.
```
Content
  ├─ LDtkFiles
  │    ├─Atlas
  │    │    └─ Cavernas_by_Adam_Saltsman.png
  │    └─ AutoLayers_1_basic.ldtk
  ├─ Images
  │    └─ ...
  └─ Fonts
       └─ ...
```
This fixes: `content.Load<Texture2D>("Atlas/Cavernas_by_Adam_Saltsman")`
To: `content.Load<Texture2D>("LDtkFiles/Atlas/Cavernas_by_Adam_Saltsman")`