### PR TITLE
Fixed world position issue in LDtkIntGrid.FromWorldToGridSpace

### DIFF
--- a/LDtk.Tests/IntGridTests.cs
+++ b/LDtk.Tests/IntGridTests.cs
@@ -1,0 +1,76 @@
+﻿namespace LDtk.Tests;
+
+using Microsoft.Xna.Framework;
+
+using Xunit;
+
+public class IntGridTests
+{
+    [Theory]
+    [InlineData(0f, 0f)]
+    [InlineData(-1.00f, -1.00f)]
+    [InlineData(14.99f, 14.99f)]
+    [InlineData(-1.01f, -1.01f, -1, -1)]
+    [InlineData(15.00f, 15.00f, 1, 1)]
+    public void FromWorldToGridSpaceVector2(float worldX, float worldY, int expectedGridSpaceX = 0, int expectedGridSpaceY = 0)
+    {
+        var intGrid = new LDtkIntGrid()
+        {
+            WorldPosition = new Point(-1, -1),
+            TileSize = 16
+        };
+
+        Vector2 positionInWorld = new Vector2(worldX, worldY);
+        Point expectedPositionInGridSpace = new Point(expectedGridSpaceX, expectedGridSpaceY);
+        Assert.Equal(intGrid.FromWorldToGridSpace(positionInWorld), expectedPositionInGridSpace);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(-1, -1)]
+    [InlineData(14, 14)]
+    [InlineData(-2, -2, -1, -1)]
+    [InlineData(15, 15, 1, 1)]
+    public void FromWorldToGridSpacePoint(int worldX, int worldY, int expectedGridSpaceX = 0, int expectedGridSpaceY = 0)
+    {
+        var intGrid = new LDtkIntGrid()
+        {
+            WorldPosition = new Point(-1, -1),
+            TileSize = 16
+        };
+
+        Point positionInWorld = new Point(worldX, worldY);
+        Point expectedPositionInGridSpace = new Point(expectedGridSpaceX, expectedGridSpaceY);
+        Assert.Equal(intGrid.FromWorldToGridSpace(positionInWorld), expectedPositionInGridSpace);
+    }
+
+    [Theory]
+    [InlineData(0, 0, true)]
+    [InlineData(1, 1, true)]
+    [InlineData(2, 2, false)]
+    [InlineData(-1, -1, false)]
+    public void ContainsPoint(int x, int y, bool isPointInGrid)
+    {
+        var intGrid = new LDtkIntGrid()
+        {
+            GridSize = new Point(2, 2)
+        };
+
+        Assert.Equal(intGrid.Contains(new Point(x, y)), isPointInGrid);
+    }
+
+    [Theory]
+    [InlineData(0f, 0f, true)]
+    [InlineData(1.99f, 1.99f, true)]
+    [InlineData(2.00f, 2.00f, false)]
+    [InlineData(-.01f, -.01f, false)]
+    public void ContainsVector2(float x, float y, bool isPointInGrid)
+    {
+        var intGrid = new LDtkIntGrid()
+        {
+            GridSize = new Point(2, 2)
+        };
+
+        Assert.Equal(intGrid.Contains(new Vector2(x, y)), isPointInGrid);
+    }
+}

--- a/LDtk/JsonPartials/LDtkIntGrid.cs
+++ b/LDtk/JsonPartials/LDtkIntGrid.cs
@@ -1,22 +1,20 @@
 namespace LDtk;
 
-using System;
-
 using Microsoft.Xna.Framework;
 
 /// <summary> LDtk IntGrid. </summary>
 public class LDtkIntGrid
 {
-    /// <summary> Gets or sets size of a tile in pixels. </summary>
+    /// <summary> Gets or sets the size of a tile in pixels. </summary>
     public int TileSize { get; set; }
 
     /// <summary> Gets or sets the underlying values of the int grid. </summary>
     public int[] Values { get; set; } = [];
 
-    /// <summary> Gets or sets worldspace start Position of the intgrid. </summary>
+    /// <summary> Gets or sets the worldspace start Position of the int grid. </summary>
     public Point WorldPosition { get; set; }
 
-    /// <summary> Gets or sets worldspace start Position of the intgrid. </summary>
+    /// <summary> Gets or sets the size of the int grid in tiles. </summary>
     public Point GridSize { get; set; }
 
     /// <summary>
@@ -68,8 +66,15 @@ public class LDtkIntGrid
     /// <summary> Convert from world pixel space to int grid space Floors the value based on <see cref="TileSize"/> to an Integer. </summary>
     public Point FromWorldToGridSpace(Vector2 position)
     {
-        int x = (int)Math.Floor(position.X / TileSize);
-        int y = (int)Math.Floor(position.Y / TileSize);
-        return new Point(x, y);
+        position -= WorldPosition.ToVector2(); // Convert from world space to local space.
+        position /= TileSize; // Covert from local space to grid space.
+        position.Floor();
+        return position.ToPoint();
+    }
+
+    /// <summary> Convert from world pixel space to int grid space. Floors the value based on <see cref="TileSize"/> to an Integer. </summary>
+    public Point FromWorldToGridSpace(Point position)
+    {
+        return FromWorldToGridSpace(position.ToVector2());
     }
 }

--- a/LDtk/JsonPartials/LDtkIntGrid.cs
+++ b/LDtk/JsonPartials/LDtkIntGrid.cs
@@ -63,7 +63,7 @@ public class LDtkIntGrid
         return point.X >= 0 && point.Y >= 0 && point.X < GridSize.X && point.Y < GridSize.Y;
     }
 
-    /// <summary> Convert from world pixel space to int grid space Floors the value based on <see cref="TileSize"/> to an Integer. </summary>
+    /// <summary> Convert from world pixel space to int grid space. Floors the value based on <see cref="TileSize"/> to an Integer. </summary>
     public Point FromWorldToGridSpace(Vector2 position)
     {
         position -= WorldPosition.ToVector2(); // Convert from world space to local space.


### PR DESCRIPTION
This PR includes a couple items:
- Fixed an issue where `LDtkIntGrid.FromWorldToGridSpace` did not take into account the int grid's world position.
- Added an overload for Point (`LDtkIntGrid.FromWorldToGridSpace(Point)`).
- Cleaned up a few XML comments.
- Added tests for int grid.

Thank you for the library :)