### PR TITLE
.NET 7+ compatibility: Addressed breaking change in System.Text.Json (.NET 7+)

### DIFF
--- a/LDtk/LDtkJsonSourceGenerator.cs
+++ b/LDtk/LDtkJsonSourceGenerator.cs
@@ -2,8 +2,27 @@ namespace LDtk;
 
 using System.Text.Json.Serialization;
 
+using Microsoft.Xna.Framework;
+
 /// <summary> The json source generator for LDtk files. </summary>
 [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
 [JsonSerializable(typeof(LDtkFile))]
 [JsonSerializable(typeof(EntityReference))]
+[JsonSerializable(typeof(EntityReference[]))]
+[JsonSerializable(typeof(TilesetRectangle))]
+[JsonSerializable(typeof(TilesetRectangle[]))]
+[JsonSerializable(typeof(Color))]
+[JsonSerializable(typeof(Color[]))]
+[JsonSerializable(typeof(Point))]
+[JsonSerializable(typeof(Point[]))]
+[JsonSerializable(typeof(Vector2))]
+[JsonSerializable(typeof(Vector2[]))]
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(bool[]))]
+[JsonSerializable(typeof(float))]
+[JsonSerializable(typeof(float[]))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(int[]))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(string[]))]
 public partial class LDtkJsonSourceGenerator : JsonSerializerContext;


### PR DESCRIPTION
I recently upgraded my project to .NET 8 and started getting an `InvalidOperationException` exception. I tracked it down to a breaking change in System.Text.Json source generators introduced in .NET 7.

See: https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/7.0/reflection-fallback#recommended-action

This PR should fix the issue and allow .NET 7+ projects to use this library 🙂 I think we could've gotten away with excluding some types (`Color`, `Point`, `Vector2`, maybe others), but I included them just for good measure. From my testing, this change covers all the field types LDtk supports.